### PR TITLE
Hiding Shutdown Watchdog Feature from Setting Tab in Instance Page

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -27,7 +27,7 @@ type CombinedProps = Props &
 
 export const LinodeWatchdogPanel: React.FC<CombinedProps> = (props) => {
   // Feature flag condition to hide the Shutdown Watchdog feature
-  const isWatchdogFeatureHidden = true;
+  const isWatchdogFeatureHidden = false;
 
   const {
     linodeId,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -26,6 +26,9 @@ type CombinedProps = Props &
   RouteComponentProps<{}>;
 
 export const LinodeWatchdogPanel: React.FC<CombinedProps> = (props) => {
+  // Feature flag condition to hide the Shutdown Watchdog feature
+  const isWatchdogFeatureHidden = true;
+
   const {
     linodeId,
     linodeActions: { updateLinode },
@@ -62,50 +65,54 @@ export const LinodeWatchdogPanel: React.FC<CombinedProps> = (props) => {
   };
 
   return (
-    <Accordion
-      heading="Shutdown Watchdog"
-      defaultExpanded
-      data-qa-watchdog-panel
-    >
-      <Grid container alignItems="center">
-        {(success || errors) && (
-          <Grid item xs={12}>
-            <Notice
-              success={Boolean(success)}
-              error={Boolean(errors)}
-              text={success || errors}
-            />
-          </Grid>
-        )}
-        <Grid item xs={12} md={2}>
-          <FormControlLabel
-            control={
-              <Toggle
-                onChange={toggleWatchdog}
-                checked={currentStatus}
-                data-qa-watchdog-toggle={currentStatus}
+    <div>
+      {isWatchdogFeatureHidden ? (
+        <Accordion
+          heading="Shutdown Watchdog"
+          defaultExpanded
+          data-qa-watchdog-panel
+        >
+          <Grid container alignItems="center">
+            {(success || errors) && (
+              <Grid item xs={12}>
+                <Notice
+                  success={Boolean(success)}
+                  error={Boolean(errors)}
+                  text={success || errors}
+                />
+              </Grid>
+            )}
+            <Grid item xs={12} md={2}>
+              <FormControlLabel
+                control={
+                  <Toggle
+                    onChange={toggleWatchdog}
+                    checked={currentStatus}
+                    data-qa-watchdog-toggle={currentStatus}
+                  />
+                }
+                label={currentStatus ? 'Enabled' : 'Disabled'}
+                aria-label={
+                  currentStatus
+                    ? 'Shutdown Watchdog is enabled'
+                    : 'Shutdown Watchdog is disabled'
+                }
+                disabled={submitting || disabled}
               />
-            }
-            label={currentStatus ? 'Enabled' : 'Disabled'}
-            aria-label={
-              currentStatus
-                ? 'Shutdown Watchdog is enabled'
-                : 'Shutdown Watchdog is disabled'
-            }
-            disabled={submitting || disabled}
-          />
-        </Grid>
-        <Grid item xs={12} md={10} lg={8} xl={6}>
-          <Typography data-qa-watchdog-desc>
-            Shutdown Watchdog, also known as Lassie, is a Linode Manager feature
-            capable of automatically rebooting your Linode if it powers off
-            unexpectedly. Lassie is not technically an availability monitoring
-            tool, but it can help get your Linode back online fast if it’s
-            accidentally powered off.
-          </Typography>
-        </Grid>
-      </Grid>
-    </Accordion>
+            </Grid>
+            <Grid item xs={12} md={10} lg={8} xl={6}>
+              <Typography data-qa-watchdog-desc>
+                Shutdown Watchdog, also known as Lassie, is a Linode Manager
+                feature capable of automatically rebooting your Linode if it
+                powers off unexpectedly. Lassie is not technically an
+                availability monitoring tool, but it can help get your Linode
+                back online fast if it’s accidentally powered off.
+              </Typography>
+            </Grid>
+          </Grid>
+        </Accordion>
+      ) : null}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description 📝
Hiding Shutdown Watchdog Feature from Setting Tab in Instance Page