### PR TITLE
Fix: Added Volume Type in Linode storage panel - Add Volume Button

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -197,7 +197,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             config_id === initialValueDefaultId
               ? undefined
               : maybeCastToNumber(config_id),
-          hardware_type: volume_type == 'nvme' ? 'ssd_volume' : 'hdd_volume',
+          hardware_type: volume_type,
         })
           .then(({ filesystem_path, label: volumeLabel }) => {
             if (hasSignedAgreement) {
@@ -360,7 +360,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                       )
                       .map((eachRegion) => ({
                         ...eachRegion,
-                        display: dcDisplayNames[eachRegion.id],
+                        display: (dcDisplayNames as { [key: string]: string })[
+                          eachRegion.id
+                        ],
                       }))}
                     selectedID={values.region}
                     width={320}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -44,6 +44,7 @@ import NoticePanel from './NoticePanel';
 import PricePanel from './PricePanel';
 import SizeField from './SizeField';
 import VolumesActionsPanel from './VolumesActionsPanel';
+import VolumeTypeSelect from 'src/components/EnhancedSelect/variants/VolumeTypeSelect/VolumeTypeSelect';
 
 type ClassNames = 'root' | 'textWrapper';
 const styles = (theme: Theme) =>
@@ -106,7 +107,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
       initialValues={initialValues}
       validationSchema={extendedCreateVolumeSchema}
       onSubmit={(values, { setSubmitting, setStatus, setErrors }) => {
-        const { label, size, config_id, tags } = values;
+        const { label, size, config_id, tags, volume_type } = values;
 
         setSubmitting(true);
 
@@ -120,6 +121,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             // If the config_id still set to default value of -1, set this to undefined, so volume gets created on back-end according to the API logic
             config_id === -1 ? undefined : maybeCastToNumber(config_id),
           tags: tags.map((v) => v.value),
+          hardware_type: volume_type,
         })
           .then(({ label: newLabel, filesystem_path }) => {
             resetEventsPolling();
@@ -230,6 +232,16 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
               isFromLinode
             />
 
+            <VolumeTypeSelect
+              label="Volume Type"
+              selectedType={values.volume_type}
+              handleSelection={(value) => setFieldValue('volume_type', value)}
+              errorText={touched.volume_type ? errors.volume_type : undefined}
+              disabled={disabled}
+              isClearable={true}
+              helperText="Select the type of volume you wish to create."
+            />
+
             <ConfigSelect
               error={touched.config_id ? errors.config_id : undefined}
               linodeId={linode_id}
@@ -286,6 +298,7 @@ interface FormState {
   linode_id: number;
   config_id: number;
   tags: _Tag[];
+  volume_type: string;
 }
 
 const initialValues: FormState = {
@@ -295,6 +308,7 @@ const initialValues: FormState = {
   linode_id: -1,
   config_id: -1,
   tags: [],
+  volume_type: 'hdd',
 };
 
 const styled = withStyles(styles);


### PR DESCRIPTION
## Description 📝
Fix: Added Volume Type in Linode storage panel - Add Volume Button

## Changes  🔄
List any change relevant to the reviewer.
- ...
- ...

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- ...
- ...

### Reproduction steps
(How to reproduce the issue, if applicable)
- ...
- ...

### Verification steps 
(How to verify changes)
- ...
- ...

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

---
## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**
- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
