### PR TITLE
Volume Tags, Volume Pricing in Resize Panel, Fixed Search Result Display Bugs

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/variants/VolumeTypeSelect/VolumeTypeSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/VolumeTypeSelect/VolumeTypeSelect.tsx
@@ -5,7 +5,7 @@ import { VolumeType } from '@linode/api-v4/lib/volumes';
 
 interface Props extends Omit<BaseSelectProps, 'onChange'> {
   handleSelection: (value: string) => void;
-  selectedType: string | null;
+  hardwareType: string | null;
   volumeTypes: VolumeType[];
   label?: string;
   helperText?: string;
@@ -26,7 +26,7 @@ const VolumeTypeSelect: React.FC<Props> = (props) => {
     isClearable,
     helperText,
     volumeTypes,
-    selectedType,
+    hardwareType,
     styles,
     required,
     width,
@@ -52,7 +52,7 @@ const VolumeTypeSelect: React.FC<Props> = (props) => {
       <Select
         isClearable={Boolean(isClearable)}
         value={
-          extendedVolumeTypes.find((type) => type.value === selectedType) ?? ''
+          extendedVolumeTypes.find((type) => type.value === hardwareType) ?? ''
         }
         label={label ?? 'Volume Type'}
         disabled={disabled}

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -23,9 +23,6 @@ export interface Props {
   onChange: (selected: Item[]) => void;
   disabled?: boolean;
   menuPlacement?: 'bottom' | 'top' | 'auto' | undefined;
-  /* -- Clanode Change -- */
-  hide?: boolean;
-  /* -- Clanode Change End -- */
 }
 
 const TagsInput: React.FC<Props> = (props) => {
@@ -38,9 +35,6 @@ const TagsInput: React.FC<Props> = (props) => {
     onChange,
     disabled,
     menuPlacement,
-    /* -- Clanode Change -- */
-    hide,
-    /* -- Clanode Change End -- */
   } = props;
 
   const [accountTags, setAccountTags] = React.useState<Tag[]>([]);
@@ -98,10 +92,6 @@ const TagsInput: React.FC<Props> = (props) => {
   const generalError = errorMap.none;
 
   const error = disabled ? undefined : labelError || tagError || generalError;
-
-  /* -- Clanode Change -- */
-  if (hide) return null;
-  /* -- Clanode Change End -- */
 
   return (
     <Select

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -91,14 +91,12 @@ const TypeToConfirm: React.FC<Props> = (props) => {
       </>
     );
   } else {
-    /* -- Clanode Change -- */
-    return visible ? (
+    return (
       <Typography className={classes.description}>
         To enable type-to-confirm, go to{' '}
         <Link to="/profile/settings">My Settings</Link>.
       </Typography>
-    ) : null;
-    /* -- Clanode Change End -- */
+    );
   }
 };
 

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -9,7 +9,6 @@ import InlineMenuAction from 'src/components/InlineMenuAction';
 
 export interface Handlers {
   onRestore: (imageID: string) => void;
-  onDeployDist: (imageID: string) => void;
   onDeploy: (imageID: string) => void;
   onEdit: (label: string, description: string, imageID: string) => void;
   onDelete: (label: string, imageID: string, status?: ImageStatus) => void;
@@ -39,13 +38,11 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
     status,
     event,
     onRestore,
-    onDeployDist,
     onDeploy,
     onEdit,
     onDelete,
     onRetry,
     onCancelFailed,
-    ...rest
   } = props;
   const actions: Action[] = React.useMemo(() => {
     const isDisabled = status && status !== 'available';
@@ -84,11 +81,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
               ? 'Image is not yet available for use.'
               : undefined,
             onClick: () => {
-              if (rest.is_public) {
-                onDeployDist(id);
-              } else {
-                onDeploy(id);
-              }
+              onDeploy(id);
             },
           },
           {

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -35,7 +35,7 @@ import {
   deleteImage as _deleteImage,
   requestImages as _requestImages,
 } from 'src/store/image/image.requests';
-// import imageEvents from 'src/store/selectors/imageEvents';
+import imageEvents from 'src/store/selectors/imageEvents';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ImageRow, { ImageWithEvent } from './ImageRow';
 import { Handlers as ImageHandlers } from './ImagesActionMenu';
@@ -277,15 +277,6 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     });
   };
 
-  const deployNewLinodeDist = (imageID: string) => {
-    const { history } = props;
-    history.push({
-      pathname: `/linodes/create/`,
-      search: `?type=Distributions&imageID=${imageID}`,
-      state: { selectedImageId: imageID },
-    });
-  };
-
   const deployNewLinode = (imageID: string) => {
     const { history } = props;
     history.push({
@@ -373,7 +364,6 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
 
   const handlers: ImageHandlers = {
     onRestore: openForRestore,
-    onDeployDist: deployNewLinodeDist,
     onDeploy: deployNewLinode,
     onEdit: openForEdit,
     onDelete: openDialog,
@@ -544,25 +534,24 @@ const mapDispatchToProps: MapDispatchToProps<ImageDispatch, {}> = (
 const withPrivateImages = connect(
   (state: ApplicationState): WithPrivateImages => {
     const { error, itemsById, lastUpdated, loading } = state.__resources.images;
-    // const events = imageEvents(state.events);
+    const events = imageEvents(state.events);
     const privateImagesWithEvents = Object.values(itemsById).reduce(
       (accum, thisImage) =>
         produce(accum, (draft) => {
-          draft.push(thisImage);
-          // if (!thisImage.is_public) {
-          //   // NB: the secondary_entity returns only the numeric portion of the image ID so we have to interpolate.
-          //   const matchingEvent = events.find(
-          //     (thisEvent) =>
-          //       `private/${thisEvent.secondary_entity?.id}` === thisImage.id ||
-          //       (`private/${thisEvent.entity?.id}` === thisImage.id &&
-          //         thisEvent.status === 'failed')
-          //   );
-          //   if (matchingEvent) {
-          //     draft.push({ ...thisImage, event: matchingEvent });
-          //   } else {
-          //     draft.push(thisImage);
-          //   }
-          // }
+          if (!thisImage.is_public) {
+            // NB: the secondary_entity returns only the numeric portion of the image ID so we have to interpolate.
+            const matchingEvent = events.find(
+              (thisEvent) =>
+                `private/${thisEvent.secondary_entity?.id}` === thisImage.id ||
+                (`private/${thisEvent.entity?.id}` === thisImage.id &&
+                  thisEvent.status === 'failed')
+            );
+            if (matchingEvent) {
+              draft.push({ ...thisImage, event: matchingEvent });
+            } else {
+              draft.push(thisImage);
+            }
+          }
         }),
       [] as ImageWithEvent[]
     );

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -59,7 +59,6 @@ const ProfileSettings: React.FC<Props & { theme: Theme }> = (props) => {
   };
   /* -- Clanode Change -- */
   const hideEmailNotifications = true;
-  const hideTypeToConfirm = true;
   /* -- Clanode Change End -- */
 
   return (
@@ -118,51 +117,43 @@ const ProfileSettings: React.FC<Props & { theme: Theme }> = (props) => {
           </Grid>
         </Grid>
       </Paper>
-      {
-        /* -- Clanode Change -- */
-        !hideTypeToConfirm ? (
-          <Paper className={classes.root}>
-            <Typography variant="h2" className={classes.title}>
-              Type-to-Confirm
-            </Typography>
-            <Typography variant="body1">
-              For some products and services, the type-to-confirm setting
-              requires entering the label before deletion.
-            </Typography>
-            <PreferenceToggle<boolean>
-              preferenceKey="type_to_confirm"
-              preferenceOptions={[true, false]}
-              localStorageKey="typeToConfirm"
-            >
-              {({
-                preference: istypeToConfirm,
-                togglePreference: toggleTypeToConfirm,
-              }: ToggleProps<boolean>) => {
-                return (
-                  <Grid container alignItems="center">
-                    <Grid item xs={12}>
-                      <FormControlLabel
-                        control={
-                          <Toggle
-                            onChange={toggleTypeToConfirm}
-                            checked={istypeToConfirm}
-                          />
-                        }
-                        label={`Type-to-confirm is${
-                          istypeToConfirm ? ' enabled' : ' disabled'
-                        }`}
+      <Paper className={classes.root}>
+        <Typography variant="h2" className={classes.title}>
+          Type-to-Confirm
+        </Typography>
+        <Typography variant="body1">
+          For some products and services, the type-to-confirm setting requires
+          entering the label before deletion.
+        </Typography>
+        <PreferenceToggle<boolean>
+          preferenceKey="type_to_confirm"
+          preferenceOptions={[true, false]}
+          localStorageKey="typeToConfirm"
+        >
+          {({
+            preference: istypeToConfirm,
+            togglePreference: toggleTypeToConfirm,
+          }: ToggleProps<boolean>) => {
+            return (
+              <Grid container alignItems="center">
+                <Grid item xs={12}>
+                  <FormControlLabel
+                    control={
+                      <Toggle
+                        onChange={toggleTypeToConfirm}
+                        checked={istypeToConfirm}
                       />
-                    </Grid>
-                  </Grid>
-                );
-              }}
-            </PreferenceToggle>
-          </Paper>
-        ) : (
-          <></>
-        )
-        /* -- Clanode Change End -- */
-      }
+                    }
+                    label={`Type-to-confirm is${
+                      istypeToConfirm ? ' enabled' : ' disabled'
+                    }`}
+                  />
+                </Grid>
+              </Grid>
+            );
+          }}
+        </PreferenceToggle>
+      </Paper>
     </>
   );
 };

--- a/packages/manager/src/features/Search/ResultGroup.tsx
+++ b/packages/manager/src/features/Search/ResultGroup.tsx
@@ -68,7 +68,12 @@ export const ResultGroup: React.FC<CombinedProps> = (props) => {
         <TableHead>
           <TableRow>
             <TableCell>Label</TableCell>
-            <TableCell>Region</TableCell>
+            {
+              /* -- Clanode Change -- */
+              // <TableCell>Region</TableCell>
+              <TableCell>{entity === 'Linodes' ? 'CPU Type' : ''}</TableCell>
+              /* -- Clanode Change End -- */
+            }
             <Hidden smDown>
               <TableCell>Created</TableCell>
               <TableCell>Tags</TableCell>
@@ -77,7 +82,15 @@ export const ResultGroup: React.FC<CombinedProps> = (props) => {
         </TableHead>
         <TableBody>
           {initial.map((result, idx: number) => (
-            <ResultRow key={idx} result={result} data-qa-result-row-component />
+            /* -- Clanode Change -- */
+            // <ResultRow key={idx} result={result} data-qa-result-row-component />
+            <ResultRow
+              key={idx}
+              result={result}
+              showRegion={entity === 'Linodes'}
+              data-qa-result-row-component
+            />
+            /* -- Clanode Change End -- */
           ))}
           {showMore &&
             hidden.map((result, idx: number) => (

--- a/packages/manager/src/features/Search/ResultRow.tsx
+++ b/packages/manager/src/features/Search/ResultRow.tsx
@@ -56,6 +56,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   result: Item;
+  /* -- Clanode Change -- */
+  showRegion?: boolean;
+  /* -- Clanode Change End -- */
 }
 
 type CombinedProps = Props;
@@ -63,7 +66,7 @@ type CombinedProps = Props;
 export const ResultRow: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const { result } = props;
+  const { result, showRegion } = props;
 
   return (
     <TableRow
@@ -82,7 +85,13 @@ export const ResultRow: React.FC<CombinedProps> = (props) => {
         <Typography variant="body1">{result.data.description}</Typography>
       </TableCell>
       <TableCell className={classes.regionCell}>
-        {result.data.region && <RegionIndicator region={result.data.region} />}
+        {
+          /* -- Clanode Change -- */
+          showRegion && result.data.region && (
+            <RegionIndicator region={result.data.region} />
+          )
+          /* -- Clanode Change End -- */
+        }
       </TableCell>
       <Hidden smDown>
         <TableCell className={classes.createdCell}>

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -53,7 +53,9 @@ import ConfigSelect, {
 import LabelField from '../VolumeDrawer/LabelField';
 import NoticePanel from '../VolumeDrawer/NoticePanel';
 import SizeField from '../VolumeDrawer/SizeField';
+/* -- Clanode Change -- */
 import VolumeTypeSelect from 'src/components/EnhancedSelect/variants/VolumeTypeSelect/VolumeTypeSelect';
+/* -- Clanode Change End -- */
 
 const useStyles = makeStyles((theme: Theme) => ({
   copy: {
@@ -194,7 +196,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
           region,
           linode_id,
           config_id,
-          volume_type,
+          /* -- Clanode Change -- */
+          hardwareType,
+          /* -- Clanode Change End -- */
         } = values;
 
         setSubmitting(true);
@@ -218,7 +222,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             config_id === initialValueDefaultId
               ? undefined
               : maybeCastToNumber(config_id),
-          hardware_type: volume_type,
+          /* -- Clanode Change -- */
+          hardware_type: hardwareType,
+          /* -- Clanode Change End -- */
         })
           .then(({ filesystem_path, label: volumeLabel }) => {
             if (hasSignedAgreement) {
@@ -344,7 +350,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                     name="size"
                     /* -- Clanode Change -- */
                     volumeTypes={volumeTypes}
-                    selectedType={values.volume_type}
+                    hardwareType={values.hardwareType}
                     /* -- Clanode Change End -- */
                     disabled={doesNotHavePermission}
                     error={touched.size ? errors.size : undefined}
@@ -360,12 +366,12 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                     <VolumeTypeSelect
                       label="Volume Type"
                       volumeTypes={volumeTypes}
-                      selectedType={values.volume_type}
+                      hardwareType={values.hardwareType}
                       handleSelection={(value) =>
-                        setFieldValue('volume_type', value)
+                        setFieldValue('hardwareType', value)
                       }
                       errorText={
-                        touched.volume_type ? errors.volume_type : undefined
+                        touched.hardwareType ? errors.hardwareType : undefined
                       }
                       disabled={doesNotHavePermission}
                       isClearable={true}
@@ -495,7 +501,9 @@ interface FormState {
   region: string;
   linode_id: number;
   config_id: number;
-  volume_type: string;
+  /* -- Clanode Change -- */
+  hardwareType: string;
+  /* -- Clanode Change End -- */
 }
 
 const initialValues: FormState = {
@@ -504,7 +512,9 @@ const initialValues: FormState = {
   region: '',
   linode_id: initialValueDefaultId,
   config_id: initialValueDefaultId,
-  volume_type: 'hdd',
+  /* -- Clanode Change -- */
+  hardwareType: 'hdd',
+  /* -- Clanode Change End -- */
 };
 
 interface StateProps {

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -116,7 +116,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
       initialValues={initialValues}
       validationSchema={extendedCreateVolumeSchema}
       onSubmit={(values, { setSubmitting, setStatus, setErrors }) => {
-        const { label, size, config_id, tags, volume_type } = values;
+        const { label, size, config_id, tags, hardwareType } = values;
 
         setSubmitting(true);
 
@@ -130,7 +130,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             // If the config_id still set to default value of -1, set this to undefined, so volume gets created on back-end according to the API logic
             config_id === -1 ? undefined : maybeCastToNumber(config_id),
           tags: tags.map((v) => v.value),
-          hardware_type: volume_type,
+          hardware_type: hardwareType,
         })
           .then(({ label: newLabel, filesystem_path }) => {
             resetEventsPolling();
@@ -251,9 +251,13 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
               <VolumeTypeSelect
                 label="Volume Type"
                 volumeTypes={volumeTypes}
-                selectedType={values.volume_type}
-                handleSelection={(value) => setFieldValue('volume_type', value)}
-                errorText={touched.volume_type ? errors.volume_type : undefined}
+                hardwareType={values.hardwareType}
+                handleSelection={(value) =>
+                  setFieldValue('hardwareType', value)
+                }
+                errorText={
+                  touched.hardwareType ? errors.hardwareType : undefined
+                }
                 disabled={disabled}
                 isClearable={true}
                 helperText="Select the type of volume you wish to create."
@@ -287,9 +291,6 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
               onChange={(selected) => setFieldValue('tags', selected)}
               value={values.tags}
               disabled={disabled}
-              /* -- Clanode Change -- */
-              hide={true}
-              /* -- Clanode Change End -- */
             />
             {
               /* -- Clanode Change -- */
@@ -297,7 +298,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
               <PricePanel
                 value={values.size}
                 currentSize={10}
-                selectedType={values.volume_type}
+                hardwareType={values.hardwareType}
                 volumeTypes={volumeTypes}
               />
               /* -- Clanode Change End -- */
@@ -325,7 +326,7 @@ interface FormState {
   linode_id: number;
   config_id: number;
   tags: _Tag[];
-  volume_type: string;
+  hardwareType: string;
 }
 
 const initialValues: FormState = {
@@ -335,7 +336,7 @@ const initialValues: FormState = {
   linode_id: -1,
   config_id: -1,
   tags: [],
-  volume_type: 'hdd',
+  hardwareType: 'hdd',
 };
 
 const styled = withStyles(styles);

--- a/packages/manager/src/features/Volumes/VolumeDrawer/EditVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/EditVolumeForm.tsx
@@ -4,9 +4,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import Form from 'src/components/core/Form';
 import Notice from 'src/components/Notice';
-/* -- Clanode Change -- */
-import { /*TagsInput,*/ Tag } from 'src/components/TagsInput';
-/* -- Clanode Change End -- */
+import TagsInput, { Tag } from 'src/components/TagsInput';
 import withVolumesRequest, {
   VolumesRequests,
 } from 'src/containers/volumesRequests.container';
@@ -121,8 +119,7 @@ const RenameVolumeForm: React.FC<CombinedProps> = (props) => {
               disabled={readOnly}
             />
 
-            {/* -- Clanode Change -- */
-            /*<TagsInput
+            <TagsInput
               tagError={
                 touched.tags
                   ? errors.tags
@@ -135,8 +132,7 @@ const RenameVolumeForm: React.FC<CombinedProps> = (props) => {
               onChange={(selected) => setFieldValue('tags', selected)}
               value={values.tags}
               disabled={readOnly}
-            />*/
-            /* -- Clanode Change -- */}
+            />
 
             <VolumesActionsPanel
               isSubmitting={isSubmitting}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/PricePanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/PricePanel.tsx
@@ -17,12 +17,12 @@ type ClassNames = 'root';
 //const getPrice = (size: number) => {
 const getPrice = (
   size: number,
-  selectedType?: string,
+  hardwareType?: string,
   volumeTypes?: VolumeType[]
 ) => {
-  const volumeType = selectedType
+  const volumeType = hardwareType
     ? volumeTypes?.find(
-        (volumeType) => volumeType.hardware_type === selectedType
+        (volumeType) => volumeType.hardware_type === hardwareType
       )
     : undefined;
   const monthlyCost = volumeType ? volumeType.price.monthly : 0;
@@ -33,17 +33,17 @@ const getPrice = (
 const getClampedPrice = (
   newSize: number,
   currentSize: number,
-  selectedType?: string,
+  hardwareType?: string,
   volumeTypes?: VolumeType[]
 ) =>
   newSize >= currentSize
     ? newSize <= MAX_VOLUME_SIZE
       ? // ? getPrice(newSize)
-        getPrice(newSize, selectedType, volumeTypes)
+        getPrice(newSize, hardwareType, volumeTypes)
       : // : getPrice(MAX_VOLUME_SIZE)
-        getPrice(MAX_VOLUME_SIZE, selectedType, volumeTypes)
+        getPrice(MAX_VOLUME_SIZE, hardwareType, volumeTypes)
     : // : getPrice(currentSize);
-      getPrice(currentSize, selectedType, volumeTypes);
+      getPrice(currentSize, hardwareType, volumeTypes);
 /* -- Clanode Change End -- */
 
 const styles = (theme: Theme) =>
@@ -57,7 +57,7 @@ interface Props {
   value: number;
   currentSize: number;
   /* -- Clanode Change -- */
-  selectedType?: string;
+  hardwareType?: string;
   volumeTypes?: VolumeType[];
   /* -- Clanode Change End -- */
 }
@@ -68,14 +68,14 @@ const PricePanel: React.FC<CombinedProps> = ({
   currentSize,
   value,
   /* -- Clanode Change -- */
-  selectedType,
+  hardwareType,
   volumeTypes,
   /* -- Clanode Change End -- */
   classes,
 }) => {
   /* -- Clanode Change -- */
   // const price = getClampedPrice(value, currentSize);
-  const price = getClampedPrice(value, currentSize, selectedType, volumeTypes);
+  const price = getClampedPrice(value, currentSize, hardwareType, volumeTypes);
   /* -- Clanode Change End -- */
 
   return (

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
@@ -1,3 +1,4 @@
+import { VolumeType } from '@linode/api-v4/lib/volumes';
 import { ResizeVolumeSchema } from '@linode/validation/lib/volumes.schema';
 import { Formik } from 'formik';
 import * as React from 'react';
@@ -13,6 +14,7 @@ import {
   handleGeneralErrors,
 } from 'src/utilities/formikErrorUtils';
 import NoticePanel from './NoticePanel';
+import PricePanel from './PricePanel';
 import SizeField from './SizeField';
 import VolumesActionsPanel from './VolumesActionsPanel';
 
@@ -23,6 +25,10 @@ interface Props {
   volumeLabel: string;
   readOnly?: boolean;
   onSuccess: (volumeLabel: string, message?: string) => void;
+  /* -- Clanode Change -- */
+  hardwareType: string;
+  volumeTypes: VolumeType[];
+  /* -- Clanode Change -- */
 }
 
 type CombinedProps = Props & VolumesRequests;
@@ -36,6 +42,10 @@ const ResizeVolumeForm: React.FC<CombinedProps> = (props) => {
     onSuccess,
     resizeVolume,
     readOnly,
+    /* -- Clanode Change -- */
+    hardwareType,
+    volumeTypes,
+    /* -- Clanode Change End -- */
   } = props;
   const initialValues = { size: volumeSize };
   const validationSchema = ResizeVolumeSchema(volumeSize);
@@ -105,6 +115,13 @@ const ResizeVolumeForm: React.FC<CombinedProps> = (props) => {
               value={values.size}
               resize={volumeSize}
               disabled={readOnly}
+            />
+
+            <PricePanel
+              value={values.size}
+              currentSize={volumeSize}
+              hardwareType={hardwareType}
+              volumeTypes={volumeTypes}
             />
 
             <VolumesActionsPanel

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
@@ -40,17 +40,25 @@ const ResizeVolumeInstructions: React.FC<CombinedProps> = (props) => {
       {message && <NoticePanel success={message} />}
 
       <div className={classes.copySection}>
-        <Typography variant="body1">
+        {
+          /* -- Clanode Change -- */
+          /* <Typography variant="body1">
           After the volume resize is complete, you'll need to restart your
           Linode for the changes to take effect.
-        </Typography>
-        <Typography variant="body1">
-          Once your Linode has restarted, make sure the volume is unmounted for
-          safety:
-        </Typography>
+        </Typography> */
+          <Typography variant="body1">
+            {/*Once your Linode has restarted, m*/} Make sure the volume is
+            unmounted for safety(the 'X' in vdX should be replaced by the letter
+            of your volume):
+          </Typography>
+          /* -- Clanode Change Emd -- */
+        }
         <CopyableTextField
           className={classes.copyField}
-          value={`umount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
+          /* -- Clanode Change -- */
+          //value={`umount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
+          value={`umount /dev/vdX`}
+          /* -- Clanode Change End -- */
           data-qa-umount
           label="Make sure the volume is unmounted for safety"
           hideLabel
@@ -64,14 +72,20 @@ const ResizeVolumeInstructions: React.FC<CombinedProps> = (props) => {
         </Typography>
         <CopyableTextField
           className={classes.copyField}
-          value={`e2fsck -f /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
+          /* -- Clanode Change -- */
+          //value={`e2fsck -f /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
+          value={`e2fsck -f /dev/vdX`}
+          /* -- Clanode Change End -- */
           data-qa-check-filesystem
           label="Run a file system check"
           hideLabel
         />
         <CopyableTextField
           className={classes.copyField}
-          value={`resize2fs /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
+          /* -- Clanode Change -- */
+          // value={`resize2fs /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
+          value={`resize2fs /dev/vdX`}
+          /* -- Clanode Change End -- */
           data-qa-resize-filesystem
           label="Resize file system to fill the new volume"
           hideLabel
@@ -84,7 +98,10 @@ const ResizeVolumeInstructions: React.FC<CombinedProps> = (props) => {
         </Typography>
         <CopyableTextField
           className={classes.copyField}
-          value={`mount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel} /mnt/${volumeLabel}`}
+          /* -- Clanode Change -- */
+          // value={`mount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel} /mnt/${volumeLabel}`}
+          value={`mount /dev/vdX /mnt/${volumeLabel}`}
+          /* -- Clanode Change End -- */
           data-qa-mount
           label="Mount back onto the filesystem"
           hideLabel

--- a/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -23,7 +23,7 @@ interface Props {
   onChange: (e: React.ChangeEvent<any>) => void;
   /* -- Clanode Change -- */
   volumeTypes?: VolumeType[];
-  selectedType?: string;
+  hardwareType?: string;
   /* -- Clanode Change End -- */
   disabled?: boolean;
   error?: string;
@@ -48,7 +48,7 @@ const SizeField: React.FC<CombinedProps> = (props) => {
     textFieldStyles,
     /* -- Clanode Change -- */
     volumeTypes,
-    selectedType,
+    hardwareType,
     /* -- Clanode Change End -- */
     ...rest
   } = props;
@@ -57,9 +57,9 @@ const SizeField: React.FC<CombinedProps> = (props) => {
     ? `This volume can range from ${resize} GB to ${MAX_VOLUME_SIZE} GB in size.`
     : undefined;
   /* -- Clanode Change -- */
-  const volumeType = selectedType
+  const volumeType = hardwareType
     ? volumeTypes?.find(
-        (volumeType) => volumeType.hardware_type === selectedType
+        (volumeType) => volumeType.hardware_type === hardwareType
       )
     : undefined;
   const monthlyCost = volumeType ? volumeType.price.monthly : 0;

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -41,11 +41,15 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
       <div className={classes.copySection}>
         <Typography variant="body1" data-qa-config-help-msg>
           To get started with a new volume, you&rsquo;ll want to create a
-          filesystem on it:
+          filesystem on it(the 'X' in vdX should be replaced by the letter of
+          your volume):
         </Typography>
         <CopyableTextField
           className={classes.copyField}
-          value={`mkfs.ext4 "${props.volumePath}"`}
+          /* -- Clanode Change -- */
+          // value={`mkfs.ext4 "${props.volumePath}"`}
+          value={`mkfs.ext4 "/dev/vdX"`}
+          /* -- Clanode Change End -- */
           data-qa-make-filesystem
           label="Create a Filesystem"
           hideLabel
@@ -71,7 +75,10 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
         </Typography>
         <CopyableTextField
           className={classes.copyField}
-          value={`mount "${props.volumePath}" "/mnt/${props.volumeLabel}"`}
+          /* -- Clanode Change -- */
+          // value={`mount "${props.volumePath}" "/mnt/${props.volumeLabel}"`}
+          value={`mount "/dev/vdX" "/mnt/${props.volumeLabel}"`}
+          /* -- Clanode Change End -- */
           data-qa-mount
           label="Mount Volume"
           hideLabel
@@ -86,7 +93,10 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
         </Typography>
         <CopyableTextField
           className={classes.copyField}
-          value={`${props.volumePath} /mnt/${props.volumeLabel} ext4 defaults,noatime,nofail 0 2`}
+          /* -- Clanode Change -- */
+          // value={`${props.volumePath} /mnt/${props.volumeLabel} ext4 defaults,noatime,nofail 0 2`}
+          value={`/dev/vdX /mnt/${props.volumeLabel} ext4 defaults,noatime,nofail 0 2`}
+          /* -- Clanode Change End -- */
           data-qa-boot-mount
           label="Mount every time your Linode boots"
           hideLabel

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
@@ -44,6 +44,9 @@ class VolumeDrawer extends React.PureComponent<CombinedProps> {
       volumeSize,
       volumeTags,
       volumePath,
+      /* -- Clanode Change -- */
+      hardwareType,
+      /* -- Clanode Change End -- */
       message,
       profile,
       grants,
@@ -75,15 +78,28 @@ class VolumeDrawer extends React.PureComponent<CombinedProps> {
         {mode === modes.RESIZING &&
           volumeId !== undefined &&
           volumeSize !== undefined &&
-          volumeLabel !== undefined && (
-            <ResizeVolumeForm
-              volumeId={volumeId}
-              volumeSize={volumeSize}
-              onClose={actions.closeDrawer}
-              volumeLabel={volumeLabel}
-              onSuccess={actions.openForResizeInstructions}
-              readOnly={readOnly}
-            />
+          volumeLabel !== undefined &&
+          /* -- Clanode Change -- */
+          hardwareType !== undefined && (
+            <UseQuery
+              queryKey="volume_types"
+              queryFn={getVolumeTypes}
+              options={volumeQueryOptions}
+            >
+              {(query) => (
+                <ResizeVolumeForm
+                  volumeId={volumeId}
+                  volumeSize={volumeSize}
+                  hardwareType={hardwareType}
+                  volumeTypes={query.data as VolumeType[]}
+                  onClose={actions.closeDrawer}
+                  volumeLabel={volumeLabel}
+                  onSuccess={actions.openForResizeInstructions}
+                  readOnly={readOnly}
+                />
+              )}
+            </UseQuery>
+            /* -- Clanode Change End -- */
           )}
         {mode === modes.CLONING &&
           volumeId !== undefined &&
@@ -196,6 +212,9 @@ interface StateProps {
   linodeLabel?: string;
   linodeRegion?: string;
   message?: string;
+  /* -- Clanode Change -- */
+  hardwareType?: string;
+  /* -- Clanode Change End -- */
 }
 
 const mapStateToProps: MapState<StateProps, {}> = (state) => {
@@ -211,6 +230,9 @@ const mapStateToProps: MapState<StateProps, {}> = (state) => {
     volumeTags,
     volumePath,
     message,
+    /* -- Clanode Change -- */
+    hardwareType,
+    /* -- Clanode Change End -- */
   } = state.volumeDrawer;
 
   return {
@@ -227,6 +249,9 @@ const mapStateToProps: MapState<StateProps, {}> = (state) => {
     volumeTags,
     volumePath,
     message,
+    /* -- Clanode Change -- */
+    hardwareType,
+    /* -- Clanode Change End -- */
   };
 };
 

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -12,7 +12,7 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 /* -- Clanode Change -- */
 // import { formatRegion } from 'src/utilities';
-/* -- Clanode Change -- */
+/* -- Clanode Change End -- */
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
 
@@ -155,11 +155,11 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
         </Grid>
       </TableCell>
       {/* -- Clanode Change -- */
-      /*region ? (
+      /* region ? (
         <TableCell data-qa-volume-region noWrap>
           {formattedRegion}
         </TableCell>
-      ) : null */
+      ) : null  */
       /* -- Clanode Change End -- */}
       <TableCell data-qa-volume-size>{size} GB</TableCell>
       {!isVolumesLanding ? (
@@ -190,6 +190,9 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           volumeTags={tags}
           size={size}
           label={label}
+          /* -- Clanode Change -- */
+          hardwareType={hardwareType}
+          /* -- Clanode Change End -- */
           onEdit={openForEdit}
           onResize={openForResize}
           onClone={openForClone}

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.test.tsx
@@ -33,6 +33,9 @@ const props: CombinedProps = {
   handleAttach: jest.fn(),
   handleDelete: jest.fn(),
   handleDetach: jest.fn(),
+  /* -- Clanode Change -- */
+  hardwareType: 'hdd',
+  /* -- Clanode Change End -- */
   ...reactRouterProps,
 };
 

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -15,7 +15,10 @@ export interface ActionHandlers {
   openForResize: (
     volumeId: number,
     volumeSize: number,
-    volumeLabel: string
+    volumeLabel: string,
+    /* -- Clanode Change -- */
+    hardwareType: string
+    /* -- Clanode Change End -- */
   ) => void;
   openForClone: (
     volumeId: number,
@@ -46,6 +49,9 @@ interface Props extends ActionHandlers {
   volumeId: number;
   volumeLabel: string;
   volumeTags: string[];
+  /* -- Clanode Change -- */
+  hardwareType: string;
+  /* -- Clanode Change End -- */
   size: number;
 }
 
@@ -68,8 +74,12 @@ export const VolumesActionMenu: React.FC<CombinedProps> = (props) => {
   };
 
   const handleResize = () => {
-    const { onResize, volumeId, size, label } = props;
-    onResize(volumeId, size, label);
+    /* -- Clanode Change -- */
+    // const { onResize, volumeId, size, label } = props;
+    // onResize(volumeId, size, label);
+    const { onResize, volumeId, size, label, hardwareType } = props;
+    onResize(volumeId, size, label, hardwareType);
+    /* -- Clanode Change End -- */
   };
 
   // const handleClone = () => {

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -76,7 +76,10 @@ interface DispatchProps {
   openForResize: (
     volumeId: number,
     volumeSize: number,
-    volumeLabel: string
+    volumeLabel: string,
+    /* -- Clanode Change -- */
+    hardwareType: string
+    /* -- Clanode Change End -- */
   ) => void;
   openForClone: (
     volumeId: number,
@@ -112,13 +115,13 @@ export const volumeHeaders = [
     dataColumn: 'label',
     sortable: true,
     widthPercent: /*40*/ 35,
-  } /*
-  {
+  },
+  /*{
     label: 'Region',
     dataColumn: 'region',
     sortable: true,
     widthPercent: 15,
-  },*/,
+  },*/
   {
     label: 'Size',
     dataColumn: 'size',
@@ -130,13 +133,6 @@ export const volumeHeaders = [
     dataColumn: 'Attached To',
     sortable: false,
     widthPercent: 30,
-  },
-  {
-    label: 'Action Menu',
-    visuallyHidden: true,
-    dataColumn: '',
-    sortable: false,
-    widthPercent: 10,
   },
   /* -- Clanode Change End -- */
 ];
@@ -389,9 +385,7 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
                 entity="volume"
                 headers={volumeHeaders}
                 isGroupedByTag={volumesAreGrouped}
-                /* -- Clanode Change -- */
-                toggleGroupByTag={/*toggleGroupVolumes*/ undefined}
-                /* -- Clanode Change End -- */
+                toggleGroupByTag={toggleGroupVolumes}
                 row={volumeRow}
                 initialOrder={{ order: 'asc', orderBy: 'label' }}
               />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -197,7 +197,7 @@ export class LinodeCreate extends React.PureComponent<
     /** Get the query params as an object, excluding the "?" */
     const queryParams = getParamsFromUrl(location.search);
 
-    const _tabs = ['Distributions', 'StackScripts', 'Snapshots'];
+    const _tabs = ['Distributions', 'StackScripts', 'Images'];
 
     /** Will be -1 if the query param is not found */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -269,9 +269,9 @@ export class LinodeCreate extends React.PureComponent<
       routeName: `${this.props.match.url}?type=StackScripts`,
     },
     {
-      title: 'Snapshots',
+      title: 'Images',
       type: 'fromImage',
-      routeName: `${this.props.match.url}?type=Snapshots`,
+      routeName: `${this.props.match.url}?type=Images`,
     },
 
     // {
@@ -535,7 +535,7 @@ export class LinodeCreate extends React.PureComponent<
               <SafeTabPanel index={2}>
                 <FromImageContent
                   variant={'private'}
-                  imagePanelTitle="Choose a Snapshot"
+                  imagePanelTitle="Choose an Image"
                   imagesData={imagesData}
                   regionsData={regionsData!}
                   typesData={typesData!}
@@ -615,17 +615,11 @@ export class LinodeCreate extends React.PureComponent<
               errorText: hasErrorFor.label,
               disabled: userCannotCreateLinode,
             }}
-            /* -- Clanode Change -- */
-            /*tagsInputProps={
+            tagsInputProps={
               this.props.createType !== 'fromLinode'
                 ? tagsInputProps
                 : undefined
-            }*/
-            tagsInputProps={{
-              ...tagsInputProps,
-              hide: true,
-            }}
-            /* -- Clanode Change End -- */
+            }
             updateFor={[tags, label, errors]}
           />
           {/* Hide for backups and clone */}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -170,7 +170,9 @@ interface State {
   loading: boolean;
   cancelBackupsAlertOpen: boolean;
   enabling: boolean;
+  /* -- Clanode Change -- */
   showAutomaticBackupSettings: boolean;
+  /* -- Clanode Change End -- */
 }
 
 type CombinedProps = PreloadedProps &
@@ -218,7 +220,9 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     loading: false,
     cancelBackupsAlertOpen: false,
     enabling: false,
+    /* -- Clanode Change -- */
     showAutomaticBackupSettings: false,
+    /* -- Clanode Change End -- */
   };
 
   windows: string[][] = [];
@@ -470,7 +474,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     const { history, linodeID } = this.props;
     history.push(
       '/linodes/create' +
-        `?type=Snapshots&imageID=${backup.id}&linodeID=${linodeID}`
+        `?type=Images&imageID=${backup.id}&linodeID=${linodeID}`
     );
   };
 
@@ -590,7 +594,6 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   SettingsForm = (): JSX.Element | null => {
     const { classes, backupsSchedule, permissions } = this.props;
     const { settingsForm } = this.state;
-    const { showAutomaticBackupSettings } = this.state;
     const getErrorFor = getAPIErrorFor(
       {
         day: 'backups.day',
@@ -625,80 +628,76 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     });
 
     return (
-      <div>
-        {showAutomaticBackupSettings ? (
-          <Paper className={classes.paper}>
-            <Typography
-              variant="h2"
-              className={classes.subTitle}
-              data-qa-settings-heading
-            >
-              Settings
-            </Typography>
-            <Typography variant="body1" data-qa-settings-desc>
-              Configure when automatic backups are initiated. The Linode Backup
-              Service will generate a backup between the selected hours every
-              day, and will overwrite the previous daily backup. The selected
-              day is when the backup is promoted to the weekly slot. Up to two
-              weekly backups are saved.
-            </Typography>
-            <FormControl className={classes.chooseDay}>
-              <Select
-                textFieldProps={{
-                  dataAttrs: {
-                    'data-qa-weekday-select': true,
-                  },
-                }}
-                options={daySelection}
-                defaultValue={defaultDaySelection}
-                onChange={this.handleSelectBackupTime}
-                label="Day of Week"
-                placeholder="Choose a day"
-                isClearable={false}
-                menuPlacement="top"
-                name="Day of Week"
-                noMarginTop
-              />
-            </FormControl>
-            <FormControl>
-              <Select
-                textFieldProps={{
-                  dataAttrs: {
-                    'data-qa-time-select': true,
-                  },
-                }}
-                options={timeSelection}
-                onChange={this.handleSelectBackupWindow}
-                label="Time of Day"
-                placeholder="Choose a time"
-                isClearable={false}
-                defaultValue={defaultTimeSelection}
-                menuPlacement="top"
-                name="Time of Day"
-                noMarginTop
-              />
-              <FormHelperText>
-                Time displayed in {getUserTimezone().replace('_', ' ')}
-              </FormHelperText>
-            </FormControl>
-            <ActionsPanel className={classes.scheduleAction}>
-              <Button
-                buttonType="primary"
-                onClick={this.saveSettings}
-                disabled={
-                  isReadOnly(permissions) ||
-                  this.inputHasChanged(backupsSchedule, settingsForm)
-                }
-                loading={this.state.settingsForm.loading}
-                data-qa-schedule
-              >
-                Save Schedule
-              </Button>
-            </ActionsPanel>
-            {errorText && <FormHelperText error>{errorText}</FormHelperText>}
-          </Paper>
-        ) : null}
-      </div>
+      <Paper className={classes.paper}>
+        <Typography
+          variant="h2"
+          className={classes.subTitle}
+          data-qa-settings-heading
+        >
+          Settings
+        </Typography>
+        <Typography variant="body1" data-qa-settings-desc>
+          Configure when automatic backups are initiated. The Linode Backup
+          Service will generate a backup between the selected hours every day,
+          and will overwrite the previous daily backup. The selected day is when
+          the backup is promoted to the weekly slot. Up to two weekly backups
+          are saved.
+        </Typography>
+        <FormControl className={classes.chooseDay}>
+          <Select
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-weekday-select': true,
+              },
+            }}
+            options={daySelection}
+            defaultValue={defaultDaySelection}
+            onChange={this.handleSelectBackupTime}
+            label="Day of Week"
+            placeholder="Choose a day"
+            isClearable={false}
+            menuPlacement="top"
+            name="Day of Week"
+            noMarginTop
+          />
+        </FormControl>
+        <FormControl>
+          <Select
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-time-select': true,
+              },
+            }}
+            options={timeSelection}
+            onChange={this.handleSelectBackupWindow}
+            label="Time of Day"
+            placeholder="Choose a time"
+            isClearable={false}
+            defaultValue={defaultTimeSelection}
+            menuPlacement="top"
+            name="Time of Day"
+            noMarginTop
+          />
+          <FormHelperText>
+            Time displayed in {getUserTimezone().replace('_', ' ')}
+          </FormHelperText>
+        </FormControl>
+        <ActionsPanel className={classes.scheduleAction}>
+          <Button
+            buttonType="primary"
+            onClick={this.saveSettings}
+            disabled={
+              isReadOnly(permissions) ||
+              this.inputHasChanged(backupsSchedule, settingsForm)
+            }
+            loading={this.state.settingsForm.loading}
+            data-qa-schedule
+          >
+            Save Schedule
+          </Button>
+        </ActionsPanel>
+        {errorText && <FormHelperText error>{errorText}</FormHelperText>}
+      </Paper>
     );
   };
 
@@ -709,6 +708,10 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     const { backups: backupsResponse } = this.state;
     const backups = aggregateBackups(backupsResponse);
 
+    /* -- Clanode Change -- */
+    const { showAutomaticBackupSettings } = this.state;
+    /* -- Clanode Change End -- */
+
     return (
       <React.Fragment>
         {disabled && <LinodePermissionsError />}
@@ -717,29 +720,41 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         ) : (
           <Paper className={classes.paper} data-qa-backup-description>
             <Typography>
-              Automatic and manual backups will be listed here
+              {
+                /* -- Clanode Change -- */
+                /* Automatic and manual backups */ 'Backups will be listed here'
+                /* -- Clanode Change End -- */
+              }
             </Typography>
           </Paper>
         )}
         <this.SnapshotForm />
-        <this.SettingsForm />
-        <Button
-          buttonType="outlined"
-          className={classes.cancelButton}
-          disabled={disabled}
-          onClick={this.handleOpenBackupsAlert}
-          data-qa-cancel
-        >
-          Cancel Backups
-        </Button>
-        <Typography
-          className={classes.cancelCopy}
-          variant="body1"
-          data-qa-cancel-desc
-        >
-          Please note that when you cancel backups associated with this Linode,
-          this will remove all existing backups.
-        </Typography>
+        {
+          /* -- Clanode Change -- */
+          showAutomaticBackupSettings ? (
+            <>
+              <this.SettingsForm />
+              <Button
+                buttonType="outlined"
+                className={classes.cancelButton}
+                disabled={disabled}
+                onClick={this.handleOpenBackupsAlert}
+                data-qa-cancel
+              >
+                Cancel Backups
+              </Button>
+              <Typography
+                className={classes.cancelCopy}
+                variant="body1"
+                data-qa-cancel-desc
+              >
+                Please note that when you cancel backups associated with this
+                Linode, this will remove all existing backups.
+              </Typography>
+            </>
+          ) : null
+          /* -- Clanode Change End -- */
+        }
         <RestoreToLinodeDrawer
           open={this.state.restoreDrawer.open}
           linodeID={linodeID}

--- a/packages/manager/src/store/volumeForm/index.ts
+++ b/packages/manager/src/store/volumeForm/index.ts
@@ -15,6 +15,9 @@ export interface State {
   linodeRegion?: string;
   message?: string;
   origin?: Origin;
+  /* -- Clanode Change -- */
+  hardwareType?: string;
+  /* -- Clanode Change End -- */
 }
 
 const actionCreator = actionCreatorFactory(`@@manager/volumesDrawer`);
@@ -116,13 +119,25 @@ interface Resizing extends Action {
   volumeId: number;
   volumeSize: number;
   volumeLabel: string;
+  /* -- Clanode Change -- */
+  hardwareType: string;
+  /* -- Clanode Change End -- */
 }
 
 export const openForResize = (
   volumeId: number,
   volumeSize: number,
-  volumeLabel: string
-): Resizing => ({ type: RESIZING, volumeId, volumeSize, volumeLabel });
+  volumeLabel: string,
+  /* -- Clanode Change -- */
+  hardwareType: string
+  /* -- Clanode Change End -- */
+): Resizing => ({
+  type: RESIZING,
+  volumeId,
+  volumeSize,
+  volumeLabel,
+  hardwareType,
+});
 
 interface Cloning extends Action {
   type: typeof CLONING;
@@ -191,6 +206,9 @@ export const defaultState: State = {
   volumeLabel: undefined,
   volumeId: undefined,
   volumeSize: undefined,
+  /* -- Clanode Change -- */
+  hardwareType: 'hdd',
+  /* -- Clanode Change End -- */
 };
 
 type ActionTypes =


### PR DESCRIPTION
Added volume tags(Implemented in proxy)
Added volume pricing in the volume resize panel.
Volume mounting an resize instructions modified to be more relevant to OpenStack.(Use of /dev/vdX)
Added type-to-confirm option back because user preferences was implemented in the proxy.
Hid regions for volumes and images in search results and displayed regions as CPU-type for Linodes.